### PR TITLE
Fix/temp disable file input

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ A GUI for MALLET's implementation of LDA Topic modeling.
 
 From the [original version](http://code.google.com/p/topic-modeling-tool
 ) by [David Newman](http://www.ics.uci.edu/~newman/) and [Arun Balagopalan](https://github.com/arunbg).
+
+This verison implements basic metadata integration as well as basic support for MALLET's advanced alpha and beta optimization routines. Regex token parsing coming soon!
+
+

--- a/TopicModelingTool/src/main/java/cc/mallet/topics/gui/TopicModelingTool.java
+++ b/TopicModelingTool/src/main/java/cc/mallet/topics/gui/TopicModelingTool.java
@@ -786,9 +786,13 @@ public class TopicModelingTool {
         buildAdvPanel();
  
         //// Input File Chooser ////
+        
+        // TEMPORARILY, single input files have been disabled. There are
+        // some bugs that make single input files hard to use; better 
+        // for now to just disable until support is solid.
 
         JFileChooser inputfc = new JFileChooser();
-        inputfc.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
+        inputfc.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
         inputfc.setCurrentDirectory(new File("."));
 
         inputDirTfield.setColumns(20);


### PR DESCRIPTION
This disables individual file input. Only the directory-of-text-files input format will be usable for now. I don't think many people tended to use the other method anyway. Yell at me if I'm wrong!